### PR TITLE
#NEW Hinzufuegen einer disable condition

### DIFF
--- a/Template/Elements/AbstractJqueryElement.php
+++ b/Template/Elements/AbstractJqueryElement.php
@@ -582,5 +582,23 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface {
 	public function build_js_validation_error(){
 		return '';
 	}
+	
+	/**
+	 * Returns an inline JS snippet which enables the widget.
+	 *
+	 * @return string
+	 */
+	public function build_js_enabler(){
+		return '$("#' . $this->get_id() . '").prop("disabled", false)';
+	}
+	
+	/**
+	 * Returns an inline JS snippet which disables the widget.
+	 *
+	 * @return string
+	 */
+	public function build_js_disabler(){
+		return '$("#' . $this->get_id() . '").prop("disabled", true)';
+	}
 }
 ?>

--- a/Template/Elements/JqueryLiveReferenceTrait.php
+++ b/Template/Elements/JqueryLiveReferenceTrait.php
@@ -1,5 +1,7 @@
 <?php namespace exface\AbstractAjaxTemplate\Template\Elements;
 
+use exface\Core\Factories\WidgetLinkFactory;
+
 trait JqueryLiveReferenceTrait {
 	
 	protected function build_js_live_reference(){
@@ -28,6 +30,92 @@ trait JqueryLiveReferenceTrait {
 	public function get_linked_template_element(){
 		$linked_element = null;
 		if ($link = $this->get_widget()->get_value_widget_link()){
+			$linked_element = $this->get_template()->get_element_by_widget_id($link->get_widget_id(), $this->get_page_id());
+		}
+		return $linked_element;
+	}
+	
+	/**
+	 * Returns a JavaScript-snippet, which is registered in the onChange-Script of the
+	 * element linked by the disable condition. Based on the condition and the value
+	 * of the linked widget, it enables and disables the current widget. 
+	 * 
+	 * @return string
+	 */
+	public function build_js_disable_condition(){
+		$output = '';
+		if (($condition = $this->get_widget()->get_disable_condition()) && $condition->widget_link){
+			$link = WidgetLinkFactory::create_from_anything($this->get_workbench(), $condition->widget_link);
+			$link->set_widget_id_space($this->get_widget()->get_id_space());
+			$linked_element = $this->get_template()->get_element_by_widget_id($link->get_widget_id(), $this->get_page_id());
+			if ($linked_element){
+				$enable_widget_script = $this->get_widget()->is_disabled() ? '' :
+							$this->build_js_enabler() . ';
+							// Sonst wird ein leeres required Widget nicht als invalide angezeigt
+							$("#' . $this->get_id() . '").' . $this->get_element_type() . '("validate");';
+				
+				$output = <<<JS
+
+						if ({$linked_element->build_js_value_getter($link->get_column_id())} {$condition->comparator} "{$condition->value}") {
+							{$this->build_js_disabler()};
+						} else {
+							{$enable_widget_script}
+						}
+JS;
+			}
+		}
+		return $output;
+	}
+	
+	/**
+	 * Returns a JavaScript-snippet, which initializes the disabled-state of elements
+	 * with a disabled condition.
+	 * 
+	 * @return string
+	 */
+	public function build_js_disable_condition_initializer(){
+		$output = '';
+		if (($condition = $this->get_widget()->get_disable_condition()) && $condition->widget_link){
+			$link = WidgetLinkFactory::create_from_anything($this->get_workbench(), $condition->widget_link);
+			$link->set_widget_id_space($this->get_widget()->get_id_space());
+			$linked_element = $this->get_template()->get_element_by_widget_id($link->get_widget_id(), $this->get_page_id());
+			if ($linked_element){
+				$output .= <<<JS
+
+		// Die unten stehende Zeile funktioniert nicht, da nach einem Prefill normalerweise ein leerer Wert zurueckkommt,
+		// deshalb wird beim initialisieren momentan einfach geschaut ob irgendein Wert vorhanden ist.
+		// if ({$linked_element->build_js_value_getter($link->get_column_id())} {$condition->comparator} "{$condition->value}") {
+		if ({$linked_element->build_js_value_getter()} {$condition->comparator} "{$condition->value}") {
+			{$this->build_js_disabler()};
+		}
+JS;
+			}
+		}
+		return $output;
+	}
+	
+	/**
+	 * Registers an onChange-Skript on the element linked by the disable condition.
+	 * 
+	 * @return \exface\AbstractAjaxTemplate\Template\Elements\JqueryLiveReferenceTrait
+	 */
+	protected function register_disable_condition_at_linked_element(){
+		if ($linked_element = $this->get_disable_condition_template_element()){
+			$linked_element->add_on_change_script($this->build_js_disable_condition());
+		}
+		return $this;
+	}
+	
+	/**
+	 * Returns the widget which is linked by the disable condition.
+	 * 
+	 * @return 
+	 */
+	public function get_disable_condition_template_element(){
+		$linked_element = null;
+		if (($condition = $this->get_widget()->get_disable_condition()) && $condition->widget_link){
+			$link = WidgetLinkFactory::create_from_anything($this->get_workbench(), $condition->widget_link);
+			$link->set_widget_id_space($this->get_widget()->get_id_space());
 			$linked_element = $this->get_template()->get_element_by_widget_id($link->get_widget_id(), $this->get_page_id());
 		}
 		return $linked_element;


### PR DESCRIPTION
AbstractJqueryElement:
- js_enabler und js_disabler hinzugefuegt

JqueryLiveReferenceTrait:
- Funktionen build_js_disable_condition(), build_js_disable_condition_initializer(), register_disable_condition_at_linked_element(), get_disable_condition_template_element() hinzugefuegt, welche ueberpruefen on ein Widget eine disable condition hat und wenn ja am verlinkten Element ein onChange Skript registrieren. Der Aufbau ist so aehnlich wie bei der Registrierung von onChange-Skripten durch value-Referenzen (weiter oben in JqueryLiveReferenceTrait).
