### PR TITLE
Layout überarbeitet

### DIFF
--- a/Template/Elements/AbstractJqueryElement.php
+++ b/Template/Elements/AbstractJqueryElement.php
@@ -19,7 +19,7 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface
     private $template = null;
 
     private $width_relative_unit = null;
-    
+
     private $width_minimum = null;
 
     private $width_default = null;
@@ -478,7 +478,7 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface
         }
         return $this->width_minimum;
     }
-    
+
     /**
      * Returns the height of one relative height unit in pixels
      *

--- a/Template/Elements/AbstractJqueryElement.php
+++ b/Template/Elements/AbstractJqueryElement.php
@@ -19,6 +19,8 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface
     private $template = null;
 
     private $width_relative_unit = null;
+    
+    private $width_minimum = null;
 
     private $width_default = null;
 
@@ -464,6 +466,19 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface
         return $this->width_relative_unit;
     }
 
+    /**
+     * Returns the minimum width of one relative width unit in pixels
+     *
+     * @return \exface\Core\CommonLogic\multitype
+     */
+    public function getWidthMinimum()
+    {
+        if (is_null($this->width_minimum)) {
+            $this->width_minimum = $this->getTemplate()->getConfig()->getOption('WIDTH_MINIMUM');
+        }
+        return $this->width_minimum;
+    }
+    
     /**
      * Returns the height of one relative height unit in pixels
      *

--- a/Template/Elements/AbstractJqueryElement.php
+++ b/Template/Elements/AbstractJqueryElement.php
@@ -373,7 +373,7 @@ abstract class AbstractJqueryElement implements ExfaceClassInterface
     {
         $dimension = $this->getWidget()->getWidth();
         if ($dimension->isRelative()) {
-            if ($dimension->getValue() != 'max') {
+            if (! $dimension->isMax()) {
                 $width = ($this->getWidthRelativeUnit() * $dimension->getValue()) . 'px';
             }
         } elseif ($dimension->isTemplateSpecific() || $dimension->isPercentual()) {

--- a/Template/Elements/JqueryLayoutInterface.php
+++ b/Template/Elements/JqueryLayoutInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace exface\AbstractAjaxTemplate\Template\Elements;
+
+interface JqueryLayoutInterface
+{
+
+    /**
+     * Returns an inline JavaScript-Snippet to start the layouting of the widget.
+     *
+     * @return string
+     */
+    public function buildJsLayouter();
+
+    /**
+     * Returns a JavaScript-Function that layouts the widget.
+     *
+     * @return string
+     */
+    public function buildJsLayouterFunction();
+}

--- a/Template/Elements/JqueryLayoutTrait.php
+++ b/Template/Elements/JqueryLayoutTrait.php
@@ -1,0 +1,15 @@
+<?php
+namespace exface\AbstractAjaxTemplate\Template\Elements;
+
+trait JqueryLayoutTrait {
+
+    /**
+     * Returns an inline JavaScript-Snippet to start the layouting of the widget.
+     *
+     * @return string
+     */
+    public function buildJsLayouter()
+    {
+        return $this->getId() . '_layouter()';
+    }
+}


### PR DESCRIPTION
AbstractJqueryElement:
- getWidthMinimum hinzugefügt, welches die minimale Breite eines Widgets zurückgibt (bestimmt im EasyUiTemplate den Moment, in welchem das Layout umbricht).