### PR TITLE
#REFACTOR Layouter JS-Funktionsnamen umgestellt

### DIFF
--- a/Template/Elements/JqueryLayoutTrait.php
+++ b/Template/Elements/JqueryLayoutTrait.php
@@ -10,6 +10,6 @@ trait JqueryLayoutTrait {
      */
     public function buildJsLayouter()
     {
-        return $this->getId() . '_layouter()';
+        return $this->buildJsFunctionPrefix() . 'layouter()';
     }
 }


### PR DESCRIPTION
Der Name der Layouter-Funktion wird über buildJsFunctionPrefix() gebildet.
